### PR TITLE
Use lazy-seq to return requests and add query namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject standalone-test-server "0.4.2-SNAPSHOT"
+(defproject standalone-test-server "0.5.0-SNAPSHOT"
   :description "An in-process server that can record requests.
                Useful for testing code that makes external http requests"
   :url "https://github.com/Mayvenn/standalone-test-server"

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :plugins [[codox "0.8.12"]]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [ring/ring-jetty-adapter "1.3.2"]]
+                 [ring/ring-codec "1.0.0"]
+                 [ring/ring-jetty-adapter "1.3.2"]
+                 [org.clojure/data.json "0.2.6"]]
   :codox {:include standalone-test-server.core
           :src-dir-uri "http://github.com/Mayvenn/standalone-test-server/blob/master/"
           :src-linenum-anchor-prefix "L"}
@@ -14,4 +16,5 @@
   :profiles
   {:dev {:source-paths ["dev"]
          :dependencies [[clj-http "1.0.1"]
-                        [org.clojure/tools.namespace "0.2.9"]]}})
+                        [org.clojure/tools.namespace "0.2.9e]]}})
+

--- a/project.clj
+++ b/project.clj
@@ -16,5 +16,5 @@
   :profiles
   {:dev {:source-paths ["dev"]
          :dependencies [[clj-http "1.0.1"]
-                        [org.clojure/tools.namespace "0.2.9e]]}})
+                        [org.clojure/tools.namespace "0.2.9"]]}})
 

--- a/src/standalone_test_server/core.clj
+++ b/src/standalone_test_server/core.clj
@@ -25,13 +25,13 @@
   handler           The handler for the recording-endpoint to wrap. Defaults to
                     a handler that returns status 200 with an empty body.
 
-  timeout           The timeout period for blocking on requests.  Defualt: 500ms
+  timeout           The timeout period for blocking on requests.  Default: 500ms
 
   Returns:
   [requests recording-handler]
 
 
-  lazy-request-promises is a lazy seq of promises that a recorded requests.
+  lazy-request-promises is a lazy seq of promises of recorded requests.
   Instead of returning lazy-request-promises, a lazy-seq is returned.  This lazy seq
   will attempt to derefence the next request as it iterates the infinite seq of
   promises. When it attempts to deref the next promise, it will block for the timeout
@@ -41,15 +41,15 @@
   instead of InputStream.
 
   Example invocations:
-  ;;Waits for a single request for 1000ms
+  ;; Waits for a single request for 1000ms
   (let [[requests endpoint] (recording-endpoint {:timeout 1000})]
     (first requests))
 
-  ;;Waits 1000ms each for two requests
+  ;; Waits 1000ms each for two requests
   (let [[requests endpoint] (recording-endpoint {:timeout 1000})]
     (take 2 requests))
 
-  ;; returns a 404 response to the http client that hits this endpoint
+  ;; Returns a 404 response to the http client that hits this endpoint
   (recording-endpoint {:handler (constantly {:status 404 :headers {}})})"
   [& [{:keys [handler timeout]
        :or {handler default-handler

--- a/src/standalone_test_server/query.clj
+++ b/src/standalone_test_server/query.clj
@@ -5,54 +5,77 @@
 
 (def json-parser json/read-str)
 (def form-parser ring/form-decode)
-(def xml-parser nil)
+(defn xml-parser [] (throw (Exception. "XML Parsing has not been implmented")))
 
 (def content-type->parser
+  "Maps a content type to a parsing function of the form String => map"
   {"application/json" json-parser
    "application/xml" xml-parser
    "text/xml" xml-parser
    "application/x-www-form-urlencoded" form-parser
    nil {}})
 
-(defn ^:private =filter [value & get-fns]
-  (partial filter #(= value ((apply comp (reverse get-fns)) %))))
-
-(defn compare-in [m keypath comp-fn val]
+(defn ^:private compare-in [m keypath comp-fn val]
   (comp-fn val (get m keypath)))
 
-(defn with-uri [uri col]
+(defn with-uri
+  "A filter function which will remove requests
+  where its :uri does not equal uri"
+  [uri col]
   (filter #(= uri (:uri %)) col))
 
-(defn with-method [method col]
+(defn with-method
+  "A filter function which will remove requests
+  where its :request-method does not equal method"
+  [method col]
+  {:pre [(keyword? method)]}
   (filter #(= method (:request-method %))
           col))
 
-(defn with-query-keys [key-set col]
+(defn with-query-keys
+  "A filter function which will remove requests
+  where its parsed :query-string's keys do not match key-set."
+  [key-set col]
   {:pre [(set? key-set)]}
   (filter #(= key-set
               (set (keys (form-parser (:query-string %)))))
           col))
 
-(defn with-query-keys [key-set col]
+(defn with-query-key-subset
+  "A filter function which will remove requests
+  where key-set is a not subset of the parsed :query-string's keys."
+  [key-set col]
   {:pre [(set? key-set)]}
   (filter #(set/subset? key-set
                         (set (keys (form-parser (:query-string %)))))
           col))
 
-(defn with-query-params [kv-map col]
+(defn with-query-params
+  "A filter function which will remove requests
+  where the parsed :query-string does not match kv-map."
+  [kv-map col]
   (filter #(= kv-map (form-parser (:query-string %))) col))
 
-(defn with-body-keys [body-keys col]
+(defn with-body-keys
+  "A filter function which will remove requests
+  where the parsed :body's keys do not match body-keys.
+
+  :body is parsed by the request's content-type"
+  [body-keys col]
   {:pre [(set? body-keys)]}
   (filter (fn [request]
             (when-let [parser (-> (get-in request [:headers "content-type"])
                                   content-type->parser)]
-              (prn (set (keys (parser (:body request)))))
               (= body-keys
                  (set (keys (parser (:body request)))))))
           col))
 
-(defn with-body-keys [body-keys col]
+(defn with-body-key-subset
+  "A filter function which will remove requests
+  where the body-keys is a subset of the parsed :body's keys.
+
+  :body is parsed by the request's content-type"
+  [body-keys col]
   {:pre [(set? body-keys)]}
   (filter (fn [request]
             (when-let [parser (-> (get-in request [:headers "content-type"])
@@ -61,16 +84,15 @@
                            (set (keys (parser (:body request)))))))
           col))
 
-(defn with-body [body col]
+(defn with-body
+  "A filter function which will remove requests
+  where the parsed :body does not match body.
+
+  :body is parsed by the request's content-type"
+  [body col]
   (filter  (fn [request]
              (when-let [parser (-> (get-in request [:headers "content-type"])
                                    content-type->parser)]
                (= body
                   (parser (:body request)))))
            col))
-
-;;Done Fetch requests by URI and http method
-;;Done Fetch requests that have a given query param
-;;Done Fetch requests that have a given query param & value
-;;Done Fetch requests that have a given form post key / values
-;;Fetch requests that have a given XML / JSON body key (s) / value (s)

--- a/src/standalone_test_server/query.clj
+++ b/src/standalone_test_server/query.clj
@@ -1,0 +1,76 @@
+(ns standalone-test-server.query
+  (:require [clojure.set :as set]
+            [clojure.data.json :as json]
+            [ring.util.codec :as ring]))
+
+(def json-parser json/read-str)
+(def form-parser ring/form-decode)
+(def xml-parser nil)
+
+(def content-type->parser
+  {"application/json" json-parser
+   "application/xml" xml-parser
+   "text/xml" xml-parser
+   "application/x-www-form-urlencoded" form-parser
+   nil {}})
+
+(defn ^:private =filter [value & get-fns]
+  (partial filter #(= value ((apply comp (reverse get-fns)) %))))
+
+(defn compare-in [m keypath comp-fn val]
+  (comp-fn val (get m keypath)))
+
+(defn with-uri [uri col]
+  (filter #(= uri (:uri %)) col))
+
+(defn with-method [method col]
+  (filter #(= method (:request-method %))
+          col))
+
+(defn with-query-keys [key-set col]
+  {:pre [(set? key-set)]}
+  (filter #(= key-set
+              (set (keys (form-parser (:query-string %)))))
+          col))
+
+(defn with-query-keys [key-set col]
+  {:pre [(set? key-set)]}
+  (filter #(set/subset? key-set
+                        (set (keys (form-parser (:query-string %)))))
+          col))
+
+(defn with-query-params [kv-map col]
+  (filter #(= kv-map (form-parser (:query-string %))) col))
+
+(defn with-body-keys [body-keys col]
+  {:pre [(set? body-keys)]}
+  (filter (fn [request]
+            (when-let [parser (-> (get-in request [:headers "content-type"])
+                                  content-type->parser)]
+              (prn (set (keys (parser (:body request)))))
+              (= body-keys
+                 (set (keys (parser (:body request)))))))
+          col))
+
+(defn with-body-keys [body-keys col]
+  {:pre [(set? body-keys)]}
+  (filter (fn [request]
+            (when-let [parser (-> (get-in request [:headers "content-type"])
+                                  content-type->parser)]
+              (set/subset? body-keys
+                           (set (keys (parser (:body request)))))))
+          col))
+
+(defn with-body [body col]
+  (filter  (fn [request]
+             (when-let [parser (-> (get-in request [:headers "content-type"])
+                                   content-type->parser)]
+               (= body
+                  (parser (:body request)))))
+           col))
+
+;;Done Fetch requests by URI and http method
+;;Done Fetch requests that have a given query param
+;;Done Fetch requests that have a given query param & value
+;;Done Fetch requests that have a given form post key / values
+;;Fetch requests that have a given XML / JSON body key (s) / value (s)

--- a/src/standalone_test_server/query.clj
+++ b/src/standalone_test_server/query.clj
@@ -13,7 +13,7 @@
    "application/xml" xml-parser
    "text/xml" xml-parser
    "application/x-www-form-urlencoded" form-parser
-   nil {}})
+   nil identity})
 
 (defn ^:private compare-in [m keypath comp-fn val]
   (comp-fn val (get m keypath)))

--- a/test/standalone_test_server/core_test.clj
+++ b/test/standalone_test_server/core_test.clj
@@ -6,17 +6,17 @@
   (:import [java.io ByteArrayInputStream]))
 
 (deftest recording-requests-with-body
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/post "http://localhost:4334/endpoint?a=b"
                  {:body (ByteArrayInputStream. (.getBytes "{\"test\":\"value\"}"))})
-      (is (= "{\"test\":\"value\"}" (->> get-requests
+      (is (= "{\"test\":\"value\"}" (->> requests
                                          (take 2)
                                          (first)
                                          :body))))))
 
 (deftest recording-several-requests-with-body
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (dotimes [n 5] (http/post "http://localhost:4334/endpoint"
                                 {:body (ByteArrayInputStream. (.getBytes (str "hello there #" n)))}))
@@ -25,52 +25,52 @@
                "hello there #2"
                "hello there #3"
                "hello there #4")
-             (->> get-requests
+             (->> requests
                   (take 5)
                   (map :body)))))))
 
 (deftest recording-without-a-request-returns-a-never-resolved-promise
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
-      (is (= '() get-requests)))))
+      (is (= '() requests)))))
 
 (deftest recording-parses-no-query-params-as-empty-map
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (let [resp (http/get "http://localhost:4334/endpoint")]
         (is (= {}
-               (-> get-requests
+               (-> requests
                    first
                    :query-params)))))))
 
 (deftest recording-parses-query-params
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (let [resp (http/get "http://localhost:4334/endpoint?hello=world&array=0&array=2&array=3")]
         (is (= {"hello" "world"
                 "array" ["0" "2" "3"]}
-               (-> get-requests
+               (-> requests
                    first
                    :query-params)))))))
 
 (deftest recording-requests-without-body
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/get "http://localhost:4334/endpoint")
-      (is (= "/endpoint" (-> get-requests first :uri))))))
+      (is (= "/endpoint" (-> requests first :uri))))))
 
 (deftest recording-requests-with-body
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/post "http://localhost:4334/endpoint"
                  {:body (ByteArrayInputStream. (.getBytes "hello there"))})
-      (is (= "hello there" (-> get-requests first :body))))))
+      (is (= "hello there" (-> requests first :body))))))
 
 (deftest recording-requests-preserves-input-stream-body-for-handler
   (let [inner-handler-body (promise)
         inner-handler (fn [req] (deliver inner-handler-body (:body req))
                         {:status 200 :body ""})
-        [get-requests endpoint] (recording-endpoint {:handler inner-handler})]
+        [requests endpoint] (recording-endpoint {:handler inner-handler})]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/post "http://localhost:4334/endpoint"
                  {:body (ByteArrayInputStream. (.getBytes "hello there"))})
@@ -85,27 +85,27 @@
 
 (deftest getting-recorded-requests
   (testing "returns requests so far when the expected request count has not been met"
-    (let [[get-requests endpoint] (recording-endpoint {:request-count 2})]
+    (let [[requests endpoint] (recording-endpoint {:request-count 2})]
       (with-standalone-server [ss (standalone-server endpoint)]
         (http/get "http://localhost:4334/endpoint")
-        (is (= 1 (count get-requests)))))))
+        (is (= 1 (count requests)))))))
 
 (deftest running-on-different-port
-  (let [[get-requests endpoint] (recording-endpoint)]
+  (let [[requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint {:port 4335})]
       (http/post "http://localhost:4335/endpoint?hello=world&a=b&array[]=4" {:headers {:content-type "application/json"}
                                                                              :body (ByteArrayInputStream. (.getBytes "{'hello':'wolrd'}"))})
-      (is (= 1 (count get-requests))))))
+      (is (= 1 (count requests))))))
 
 (deftest specifying-multiple-servers-together
   (testing "with-standalone-server allows multiple server bindings"
-    (let [[get-requests endpoint] (recording-endpoint {:request-count 2})]
+    (let [[requests endpoint] (recording-endpoint {:request-count 2})]
       (with-standalone-server [s1 (standalone-server endpoint)
                                s2 (standalone-server endpoint {:port 4335})]
         (http/get "http://localhost:4334/endpoint")
         (http/get "http://localhost:4335/endpoint")
-        (is (= "/endpoint" (-> get-requests first :uri)))
-        (is (= 2 (count get-requests))))
+        (is (= "/endpoint" (-> requests first :uri)))
+        (is (= 2 (count requests))))
 
       (testing "while properly shutting the servers down"
         (is (thrown? java.net.ConnectException

--- a/test/standalone_test_server/core_test.clj
+++ b/test/standalone_test_server/core_test.clj
@@ -5,71 +5,41 @@
             [clj-http.client :as http])
   (:import [java.io ByteArrayInputStream]))
 
-(deftest lazy-recording-requests-with-body
-  (let [[get-requests endpoint] (lazy-recording-endpoint)]
+(deftest recording-requests-with-body
+  (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/post "http://localhost:4334/endpoint?a=b"
                  {:body (ByteArrayInputStream. (.getBytes "{\"test\":\"value\"}"))})
-      (->> (get-requests)
-           (take 5)
-           (map #(deref % 1000 nil))
-           (map :body)))))
+      (is (= "{\"test\":\"value\"}" (->> get-requests
+                                         (take 2)
+                                         (first)
+                                         :body))))))
 
-(deftest lazy-recording-several-requests-with-body
-  (let [[get-requests endpoint] (lazy-recording-endpoint)]
+(deftest recording-several-requests-with-body
+  (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (dotimes [n 5] (http/post "http://localhost:4334/endpoint"
                                 {:body (ByteArrayInputStream. (.getBytes (str "hello there #" n)))}))
-      (is (= ["hello there #0"
-              "hello there #1"
-              "hello there #2"
-              "hello there #3"
-              "hello there #4"] (->> (get-requests)
-                                     (take 5)
-                                     (map #(deref % 1000 nil))
-                                     (map :body)))))))
+      (is (= '("hello there #0"
+               "hello there #1"
+               "hello there #2"
+               "hello there #3"
+               "hello there #4")
+             (->> get-requests
+                  (take 5)
+                  (map :body)))))))
 
-(deftest lazy-recording-without-a-request-returns-a-never-resolved-promise
-  (let [[get-requests endpoint] (lazy-recording-endpoint)]
+(deftest recording-without-a-request-returns-a-never-resolved-promise
+  (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
-      (is (= nil (-> (get-requests)
-                     first
-                     (deref 1000 nil)))))))
-
-(deftest lazy-recording-with-a-handler
-  (let [request-handler {:handler (constantly {:status 201 :headers {}})}
-        [get-requests endpoint] (lazy-recording-endpoint request-handler)]
-    (with-standalone-server [ss (standalone-server endpoint)]
-      (let [resp (http/get "http://localhost:4334/endpoint")]
-        (is (= 201 (:status resp)))))))
-
-(deftest lazy-recording-parses-no-query-params-as-empty-map
-  (let [[get-requests endpoint] (lazy-recording-endpoint)]
-    (with-standalone-server [ss (standalone-server endpoint)]
-      (let [resp (http/get "http://localhost:4334/endpoint")]
-        (is (= {}
-               (-> (get-requests)
-                   first
-                   (deref 1000 nil)
-                   :query-params)))))))
-
-(deftest lazy-recording-parses-query-params
-  (let [[get-requests endpoint] (lazy-recording-endpoint)]
-    (with-standalone-server [ss (standalone-server endpoint)]
-      (let [resp (http/get "http://localhost:4334/endpoint?hello=world&array=0&array=2&array=3")]
-        (is (= {"hello" "world"
-                "array" ["0" "2" "3"]}
-               (-> (get-requests)
-                   first
-                   (deref 1000 nil)
-                   :query-params)))))))
+      (is (= '() get-requests)))))
 
 (deftest recording-parses-no-query-params-as-empty-map
   (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (let [resp (http/get "http://localhost:4334/endpoint")]
         (is (= {}
-               (-> (get-requests)
+               (-> get-requests
                    first
                    :query-params)))))))
 
@@ -79,7 +49,7 @@
       (let [resp (http/get "http://localhost:4334/endpoint?hello=world&array=0&array=2&array=3")]
         (is (= {"hello" "world"
                 "array" ["0" "2" "3"]}
-               (-> (get-requests)
+               (-> get-requests
                    first
                    :query-params)))))))
 
@@ -87,14 +57,14 @@
   (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/get "http://localhost:4334/endpoint")
-      (is (= "/endpoint" (-> (get-requests) first :uri))))))
+      (is (= "/endpoint" (-> get-requests first :uri))))))
 
 (deftest recording-requests-with-body
   (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint)]
       (http/post "http://localhost:4334/endpoint"
                  {:body (ByteArrayInputStream. (.getBytes "hello there"))})
-      (is (= "hello there" (-> (get-requests) first :body))))))
+      (is (= "hello there" (-> get-requests first :body))))))
 
 (deftest recording-requests-preserves-input-stream-body-for-handler
   (let [inner-handler-body (promise)
@@ -118,14 +88,14 @@
     (let [[get-requests endpoint] (recording-endpoint {:request-count 2})]
       (with-standalone-server [ss (standalone-server endpoint)]
         (http/get "http://localhost:4334/endpoint")
-        (is (= 1 (count (get-requests {:timeout 10}))))))))
+        (is (= 1 (count get-requests)))))))
 
 (deftest running-on-different-port
   (let [[get-requests endpoint] (recording-endpoint)]
     (with-standalone-server [ss (standalone-server endpoint {:port 4335})]
       (http/post "http://localhost:4335/endpoint?hello=world&a=b&array[]=4" {:headers {:content-type "application/json"}
                                                                              :body (ByteArrayInputStream. (.getBytes "{'hello':'wolrd'}"))})
-      (is (= 1 (count (get-requests {:timeout 10})))))))
+      (is (= 1 (count get-requests))))))
 
 (deftest specifying-multiple-servers-together
   (testing "with-standalone-server allows multiple server bindings"
@@ -134,8 +104,8 @@
                                s2 (standalone-server endpoint {:port 4335})]
         (http/get "http://localhost:4334/endpoint")
         (http/get "http://localhost:4335/endpoint")
-        (is (= "/endpoint" (-> (get-requests) first :uri)))
-        (is (= 2 (count (get-requests)))))
+        (is (= "/endpoint" (-> get-requests first :uri)))
+        (is (= 2 (count get-requests))))
 
       (testing "while properly shutting the servers down"
         (is (thrown? java.net.ConnectException

--- a/test/standalone_test_server/query_test.clj
+++ b/test/standalone_test_server/query_test.clj
@@ -80,9 +80,9 @@
 (deftest query-by-with-json-body-keys
   (let [requests [(assoc json-body-request-fixture :body "{\"not_test\":\"value\"}")
                   json-body-request-fixture]]
-    (is (= [json-body-request-fixture ]
+    (is (= [json-body-request-fixture]
            (->> requests
-                (with-body-keys #{"test"}))))))
+                (with-body-key-subset #{"test"}))))))
 
 (deftest query-by-json-body-eq
   (let [requests [(assoc json-body-request-fixture :body "{\"test\":\"not_value\", \"second_test\":\"second_value\"}")
@@ -104,7 +104,7 @@
                   form-body-request-fixture]]
     (is (= [form-body-request-fixture ]
            (->> requests
-                (with-body-keys #{"test"}))))))
+                (with-body-key-subset #{"test"}))))))
 
 (deftest query-by-form-body-eq
   (let [requests [(assoc json-body-request-fixture :body "{\"test\":\"not_value\"}")
@@ -120,15 +120,15 @@
       (http/post "http://localhost:4334/endpoint?a=b"
                  {:headers {:content-type "application/json"}
                   :body (ByteArrayInputStream. (.getBytes "{\"test\":\"value\"}"))})
+      (http/get "http://localhost:4334/endpoint"
+                 {})
       (http/post "http://localhost:4334/endpoint"
                  {:headers {:content-type "application/x-www-form-urlencoded"}
                   :body (ByteArrayInputStream. (.getBytes "test=value&second_test=second_value"))})
-      (http/get "http://localhost:4334/endpoint"
-                 {})
       (http/get "http://localhost:4334/not_endpoint?c=d"
                  {})
       (is (= ["{\"test\":\"value\"}" "test=value&second_test=second_value"]
              (->> get-requests
-                  (with-body-keys #{"test"})
+                  (with-body-key-subset #{"test"})
                   (with-method :post)
                   (map :body)))))))

--- a/test/standalone_test_server/query_test.clj
+++ b/test/standalone_test_server/query_test.clj
@@ -1,0 +1,134 @@
+(ns standalone-test-server.query-test
+  (:require [clj-http.client :as http]
+            [standalone-test-server.query :refer :all]
+            [standalone-test-server.core :refer :all]
+            [clojure.test :refer :all])
+  (:import [java.io ByteArrayInputStream]))
+
+(def json-body-request-fixture {:ssl-client-cert nil,
+                                :remote-addr "127.0.0.1",
+                                :headers
+                                {"host" "localhost:4334",
+                                 "transfer-encoding" "chunked",
+                                 "user-agent" "Apache-HttpClient/4.3.5 (java 1.5)",
+                                 "accept-encoding" "gzip, deflate",
+                                 "content-type" "application/json",
+                                 "connection" "close"},
+                                :server-port 4334,
+                                :content-length nil,
+                                :query-params {"a" "b"},
+                                :character-encoding nil,
+                                :uri "/endpoint",
+                                :server-name "localhost",
+                                :query-string "a=b",
+                                :body "{\"test\":\"value\", \"second_test\":\"second_value\"}",
+                                :scheme :http,
+                                :request-method :post})
+
+(def form-body-request-fixture {:ssl-client-cert nil,
+                                :remote-addr "127.0.0.1",
+                                :headers
+                                {"host" "localhost:4334",
+                                 "transfer-encoding" "chunked",
+                                 "user-agent" "Apache-HttpClient/4.3.5 (java 1.5)",
+                                 "accept-encoding" "gzip, deflate",
+                                 "content-type" "application/x-www-form-urlencoded",
+                                 "connection" "close"},
+                                :server-port 4334,
+                                :content-length nil,
+                                :query-params {"a" "b"},
+                                :character-encoding nil,
+                                :uri "/endpoint",
+                                :server-name "localhost",
+                                :query-string "a=b",
+                                :body "test=value&second_test=second_value",
+                                :scheme :http,
+                                :request-method :post})
+
+(def timeout 10)
+
+(defmacro test-both-query [expected count col & filters])
+
+(deftest query-by-query-keys
+  (let [requests [json-body-request-fixture
+                  (assoc json-body-request-fixture :query-string "b=a")]]
+    (is (= [json-body-request-fixture]
+           (->> requests
+                (with-query-keys #{"a"}))))))
+
+(deftest query-by-uri
+  (let [requests [json-body-request-fixture
+                  (assoc json-body-request-fixture :uri "/not_endpoint")]]
+    (is (= [json-body-request-fixture]
+           (->> requests
+                (with-uri "/endpoint"))))))
+
+(deftest query-by-method
+  (let [requests [(assoc json-body-request-fixture :request-method :get)
+                  json-body-request-fixture]]
+    (is (= [json-body-request-fixture]
+           (->> requests
+                (with-method :post))))))
+
+(deftest query-by-json-body-keys
+  (let [requests [(assoc json-body-request-fixture :body "{\"not_test\":\"value\"}")
+                  json-body-request-fixture]]
+    (is (= [json-body-request-fixture]
+           (->> requests
+                (with-body-keys #{"test" "second_test"}))))))
+
+(deftest query-by-with-json-body-keys
+  (let [requests [(assoc json-body-request-fixture :body "{\"not_test\":\"value\"}")
+                  json-body-request-fixture]]
+    (is (= [json-body-request-fixture ]
+           (->> requests
+                (with-body-keys #{"test"}))))))
+
+(deftest query-by-json-body-eq
+  (let [requests [(assoc json-body-request-fixture :body "{\"test\":\"not_value\", \"second_test\":\"second_value\"}")
+                  json-body-request-fixture]]
+    (is (= [json-body-request-fixture ]
+           (->> requests
+                (with-body {"second_test" "second_value"
+                            "test" "value"}))))))
+
+(deftest query-by-form-body-keys
+  (let [requests [(assoc form-body-request-fixture :body "not_test=value")
+                  form-body-request-fixture]]
+    (is (= [form-body-request-fixture ]
+           (->> requests
+                (with-body-keys #{"test" "second_test"}))))))
+
+(deftest query-by-with-form-body-keys
+  (let [requests [(assoc form-body-request-fixture :body "not_test=value")
+                  form-body-request-fixture]]
+    (is (= [form-body-request-fixture ]
+           (->> requests
+                (with-body-keys #{"test"}))))))
+
+(deftest query-by-form-body-eq
+  (let [requests [(assoc json-body-request-fixture :body "{\"test\":\"not_value\"}")
+                  json-body-request-fixture]]
+    (is (= [json-body-request-fixture]
+           (->> requests
+                (with-body {"second_test" "second_value"
+                            "test" "value"}))))))
+
+(deftest future-integration
+  (let [[get-requests endpoint] (recording-endpoint)]
+    (with-standalone-server [ss (standalone-server endpoint)]
+      (http/post "http://localhost:4334/endpoint?a=b"
+                 {:headers {:content-type "application/json"}
+                  :body (ByteArrayInputStream. (.getBytes "{\"test\":\"value\"}"))})
+      (http/post "http://localhost:4334/endpoint"
+                 {:headers {:content-type "application/x-www-form-urlencoded"}
+                  :body (ByteArrayInputStream. (.getBytes "test=value&second_test=second_value"))})
+      (http/get "http://localhost:4334/endpoint"
+                 {})
+      (http/get "http://localhost:4334/not_endpoint?c=d"
+                 {})
+      (is (= ["{\"test\":\"value\"}" "test=value&second_test=second_value"]
+             (->> get-requests
+                  (with-body-keys #{"test"})
+                  (with-method :post)
+                  (map :body)))))))


### PR DESCRIPTION
This pull request changes how requests are recorded and returned.  

It aims to remove the need to specify how many requests will be made while allowing users to query recorded requests more readily.
